### PR TITLE
Do not require file title to be the first file element

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,6 +51,24 @@ const findLinks = (ast: MarkdownNode): string[] => {
   return links;
 };
 
+const findTitle = (ast: MarkdownNode): string | null => {
+  if (!ast.children) {
+    return null;
+  }
+
+  for (const child of ast.children) {
+    if (
+      child.type === "heading" &&
+      child.depth === 1 &&
+      child.children &&
+      child.children.length > 0
+    ) {
+      return child.children[0].value!;
+    }
+  }
+  return null;
+};
+
 const parseFile = async (source: string) => {
   const buffer = await vscode.workspace.fs.readFile(vscode.Uri.file(source));
   const content = new TextDecoder("utf-8").decode(buffer);
@@ -62,17 +80,7 @@ const parseFile = async (source: string) => {
   // - parse that YAML
   // - wiki links?
 
-  let title: string | null = null;
-  if (
-    ast.children &&
-    ast.children.length > 0 &&
-    ast.children[0].type === "heading" &&
-    ast.children[0].depth === 1 &&
-    ast.children[0].children &&
-    ast.children[0].children.length > 0
-  ) {
-    title = ast.children[0].children[0].value!;
-  }
+  let title: string | null = findTitle(ast);
 
   if (!title) {
     return;


### PR DESCRIPTION
Change title detection logic to find the first level 1 heading, while allowing content before it.