### PR TITLE
Match color scheme to VS Code theme and fix active-node-highlight on Windows 

### DIFF
--- a/static/webview.html
+++ b/static/webview.html
@@ -7,19 +7,22 @@
         margin: 0;
         padding: 0;
         overflow: hidden;
-        background-color: #fff;
+        background-color: var(--vscode-editor-background);
       }
 
       .links line {
-        stroke: #ccc;
+        stroke: var(--vscode-editor-foreground);
+        opacity: 0.5;
       }
 
       .nodes circle {
         cursor: pointer;
+        fill: var(--vscode-editor-foreground);
       }
 
       .text text {
         cursor: pointer;
+        fill: var(--vscode-editor-foreground);
       }
 
       .buttons {
@@ -29,15 +32,13 @@
         display: flex;
         flex-direction: column;
         margin: 16px;
+        cursor: default;
       }
 
       .buttons span > span {
-        color: #000;
+        color: var(--vscode-foreground);
       }
 
-      span {
-        color: #666;
-      }
     </style>
     <script src="--REPLACE-WITH-D3-URI--"></script>
   </head>

--- a/static/webview.html
+++ b/static/webview.html
@@ -18,11 +18,20 @@
       .nodes circle {
         cursor: pointer;
         fill: var(--vscode-editor-foreground);
+        transition: all 0.15s ease-out;
       }
 
       .text text {
         cursor: pointer;
         fill: var(--vscode-editor-foreground);
+      }
+      .nodes [active],
+      .text [active] {
+        cursor: pointer;
+        fill: var(--vscode-textLink-foreground);
+      }
+      .nodes circle[active] {
+        r: 6;
       }
 
       .buttons {
@@ -127,11 +136,16 @@
           case "fileOpen":
             let path = message.payload.path;
             if (path.endsWith(".git")) {
-              path = path.split("").slice(0, -4).join("");
+              path = path.slice(0, -4);
             }
 
-            //node.attr("fill", (d) => getNodeColor(d, path));
-            //text.attr("fill", (d) => getNodeColor(d, path));
+            const fixSlashes = (input) => {
+              const onLocalWindowsFilesystem = navigator.platform == "Win32" && /^\w:\\/.test(input);
+              return onLocalWindowsFilesystem ? input.replace(/\//g, "\\") : input;
+            }
+
+            node.attr("active", (d) => fixSlashes(d.path) === path ? true : null);
+            text.attr("active", (d) => fixSlashes(d.path) === path ? true : null);
             break;
         }
       });

--- a/static/webview.html
+++ b/static/webview.html
@@ -54,8 +54,8 @@
       const FONT_SIZE = 14;
       const TICKS = 5000;
       const FONT_BASELINE = 15;
-      const activeNodeColor = "#0050ff";
-      const nodeColor = "#777";
+      //const activeNodeColor = "#0050ff";
+      //const nodeColor = "#777";
 
       let nodesData = [];
       let linksData = [];
@@ -105,10 +105,10 @@
         return true;
       };
 
-      const getNodeColor = (node, active) => {
-        console.log(node, active);
-        return node.path === active ? activeNodeColor : nodeColor;
-      };
+      // const getNodeColor = (node, active) => {
+      //   console.log(node, active);
+      //   return node.path === active ? activeNodeColor : nodeColor;
+      // };
 
       window.addEventListener("message", (event) => {
         const message = event.data;
@@ -130,8 +130,8 @@
               path = path.split("").slice(0, -4).join("");
             }
 
-            node.attr("fill", (d) => getNodeColor(d, path));
-            text.attr("fill", (d) => getNodeColor(d, path));
+            //node.attr("fill", (d) => getNodeColor(d, path));
+            //text.attr("fill", (d) => getNodeColor(d, path));
             break;
         }
       });
@@ -215,7 +215,7 @@
           .enter()
           .append("circle")
           .attr("r", RADIUS)
-          .attr("fill", (d) => getNodeColor(d))
+          // .attr("fill", (d) => getNodeColor(d))
           .on("click", onClick)
           .merge(node);
 
@@ -236,7 +236,7 @@
           .attr("font-size", `${FONT_SIZE}px`)
           .attr("text-anchor", "middle")
           .attr("alignment-baseline", "central")
-          .attr("fill", (d) => getNodeColor(d))
+          // .attr("fill", (d) => getNodeColor(d))
           .on("click", onClick)
           .merge(text);
 


### PR DESCRIPTION
VS Code provides CSS vars for the current theme colors, so I switched out the CSS to use those, and removed hard-coded colors in the <script> portion of webview.html. I also fixed a bug with active-file highlighting not working on Windows due to handling of "/" and "\".

Note: I noticed that the active-file highlighting only works once per file, but it turns out that the `vscode.workspace.onDidOpenTextDocument` event is only fired once per file, at least for me.

Cool extension, btw! Excited to see where it goes.