### PR TITLE
Support [file-name] ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ When active file in the editor changes and it matches one of the files in the gr
 
 - Title is always the first Markdown heading of depth 1, i.e. `# Title`.
 - Files which do not have a title do not appear in the graph.
-- Files can link to other files using [local Markdown links](docs/local-links.md) or [ID-based links](docs/id-based-links.md).
+- Files can link to other files using [local Markdown links](docs/local-links.md), [ID-based links](docs/id-based-links.md), or `[file-name]` links.
 - The graph is not directed. It doesn't show which file has the link and which one is linked.
 - Directory structure is not relevant for the graph. All that matters is the mutual links between files.
 

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -7,6 +7,7 @@ import * as frontmatter from "remark-frontmatter";
 import { MarkdownNode, Graph } from "./types";
 import { TextDecoder } from "util";
 import { findTitle, findLinks, id, FILE_ID_REGEXP } from "./utils";
+import { basename } from "path";
 
 let idToPath: Record<string, string> = {};
 
@@ -71,8 +72,12 @@ export const findFileId = async (filePath: string): Promise<string | null> => {
   return match ? match[1] : null;
 };
 
+export const generateFileIdFromFilePath = (filePath: string) => {
+  return basename(filePath).split(".")[0];
+};
+
 export const learnFileId = async (_graph: Graph, filePath: string) => {
-  const id = await findFileId(filePath);
+  let id = (await findFileId(filePath)) || generateFileIdFromFilePath(filePath);
   if (id !== null) {
     idToPath[id] = filePath;
   }

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -72,15 +72,17 @@ export const findFileId = async (filePath: string): Promise<string | null> => {
   return match ? match[1] : null;
 };
 
-export const generateFileIdFromFilePath = (filePath: string) => {
-  return basename(filePath).split(".")[0];
-};
-
 export const learnFileId = async (_graph: Graph, filePath: string) => {
-  let id = (await findFileId(filePath)) || generateFileIdFromFilePath(filePath);
+  const id = await findFileId(filePath);
   if (id !== null) {
     idToPath[id] = filePath;
   }
+
+  const fileName = basename(filePath);
+  idToPath[fileName] = filePath;
+
+  const fileNameWithoutExt = fileName.split(".").slice(0, -1).join(".");
+  idToPath[fileNameWithoutExt] = filePath;
 };
 
 export const parseDirectory = async (


### PR DESCRIPTION
This is a naive implementation to add support for `[wiki-link]` format where the file id is file name, either with or without an extension.

As discussed with @tchayen [on twitter](https://twitter.com/tchayen/status/1276197705287680007), this may add edge cases to the resolution, but since we're not changing the link parsing and only adding new indices to previously un-indexable pages, this should not break anything.

The [first commit](https://github.com/tchayen/markdown-links/pull/13/commits/e61fadded1fb8b1ca607d53e563a7fa39e2fdf15) on this branch had a slightly more conservative approach where files were only indexed by extensionless name IF they didn't have a file id, but I think the final approach in the diff is more robust.