### PR TITLE
Add autostart functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "license": "MIT",
   "activationEvents": [
+    "onLanguage:markdown",
     "onCommand:markdown-links.showGraph"
   ],
   "main": "./dist/extension.js",
@@ -29,7 +30,7 @@
     "commands": [
       {
         "command": "markdown-links.showGraph",
-        "title": "Show Graph"
+        "title": "Markdown Links: Show Graph"
       }
     ],
     "configuration": {
@@ -49,6 +50,11 @@
           "type": "string",
           "default": "\\d{14}",
           "description": "Regular extension used to find file IDs. First match of this regex in file contents, excluding [[links]], will be used as the file ID. This file ID can be used for wiki-style links."
+        },
+        "markdown-links.autoStart": {
+          "type": "boolean",
+          "default": false,
+          "description": "Should Markdown Links automatically start when a markdown file is opened."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { TextDecoder } from "util";
 import * as path from "path";
 import { parseFile, parseDirectory, learnFileId } from "./parsing";
-import { filterNonExistingEdges, getColumnSetting } from "./utils";
+import { filterNonExistingEdges, getColumnSetting, getConfiguration } from "./utils";
 import { Graph } from "./types";
 
 const watch = (
@@ -141,6 +141,12 @@ export function activate(context: vscode.ExtensionContext) {
       watch(context, panel, graph);
     })
   );
+
+  const shouldAutoStart = getConfiguration("autoStart");
+
+  if (shouldAutoStart) {
+    vscode.commands.executeCommand("markdown-links.showGraph");
+  }
 }
 
 async function getWebviewContent(


### PR DESCRIPTION
Firstly, thank you for the great extension. I started using it with [Foam](https://foambubble.github.io/foam/) and I have to say its rather nice.

I looked at the Roadmap and saw that auto start was on the list, so I thought I would give it a try. I implemented it in a pretty simple way, but it works as expected. If you start VSCode and a markdown file is currently open, it will automatically open the graph pane. If you don't have one open, but then open one at a later time after startup, it will launch the graph pane too.

To make it configurable I added an `autoStart` config option, defaulting to `false`.
![autostart](https://user-images.githubusercontent.com/20936452/85916715-05401380-b819-11ea-8a84-8fd7c71cc4f4.PNG)


And as a tiny nit (I can revert it if you want), I made the command display name more consistent with other extensions, by prefixing it with `Markdown Links: `

Before:
![before](https://user-images.githubusercontent.com/20936452/85916700-f2c5da00-b818-11ea-8aa8-7c9aad72fc45.PNG)

After:
![after](https://user-images.githubusercontent.com/20936452/85916706-f9545180-b818-11ea-8080-b4fe0bf45ca3.PNG)