### PR TITLE
Add support for spaces in link name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Support for Markdown Note's [[wiki-links]]-style links to graph.
+
 ## [0.6.0] – 2020-06-26
 
 ### Added

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,12 +42,9 @@ export const findTitle = (ast: MarkdownNode): string | null => {
 };
 
 export const id = (path: string): string => {
-  return md5(path);
-
-  // Extracting file name without extension:
-  // const fullPath = path.split("/");
-  // const fileName = fullPath[fullPath.length - 1];
-  // return fileName.split(".")[0];
+  const withoutExtension = path.replace(/\.\w+$/, "");
+  const withDashes = withoutExtension.replace(/ /g, "-");
+  return md5(withDashes);
 };
 
 export const getConfiguration = (key: string) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,8 +43,10 @@ export const findTitle = (ast: MarkdownNode): string | null => {
 
 export const id = (path: string): string => {
   const withoutExtension = path.replace(/\.\w+$/, "");
-  const withDashes = withoutExtension.replace(/ /g, "-");
-  return md5(withDashes);
+  const withoutIncludedDashes = withoutExtension.replace(/ - /g, "-");
+  const withDashesInsteadOfBlanks = withoutIncludedDashes.replace(/ /g, "-");
+  const lowercased = withDashesInsteadOfBlanks.toLowerCase();
+  return md5(lowercased);
 };
 
 export const getConfiguration = (key: string) =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,12 +41,23 @@ export const findTitle = (ast: MarkdownNode): string | null => {
   return null;
 };
 
-export const id = (path: string): string => {
+/**
+ * Creates slugs from paths,
+ * akin to Markdown Notes'
+ * naming convention.
+ * See https://github.com/kortina/vscode-markdown-notes#wiki-links
+ */
+const slugify = (path: string): string => {
   const withoutExtension = path.replace(/\.\w+$/, "");
   const withoutIncludedDashes = withoutExtension.replace(/ - /g, "-");
   const withDashesInsteadOfBlanks = withoutIncludedDashes.replace(/ /g, "-");
   const lowercased = withDashesInsteadOfBlanks.toLowerCase();
-  return md5(lowercased);
+  return lowercased;
+};
+
+export const id = (path: string): string => {
+  const slug = slugify(path);
+  return md5(slug);
 };
 
 export const getConfiguration = (key: string) =>


### PR DESCRIPTION
Thank y'all for creating this wonderful VSC extension! I've been using it with Foam and quite liked it.

I noticed that Markdown Links doesn't pick up some of the wiki-links that Markdown Notes generates. This PR aims to fix this.

## Motivation
Instead of writing [[how-to-find-interesting-ideas-david-perell.md]] (Markdown Notes' file naming convention), users should be able to write [[How to find interesting ideas - David Perell]] and still have it be picked up by Markdown Links' Graph.

## What is PR does
This PR makes the graph ID scheme adhere to Markdown Notes' naming convention.