### PR TITLE
Add custom file extension support (Needs reviewing) 

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ const watch = (
   }
 
   const watcher = vscode.workspace.createFileSystemWatcher(
-    new vscode.RelativePattern(vscode.workspace.rootPath, "**/*{" + getFileTypesSetting().join(",") +"}"),
+    new vscode.RelativePattern(vscode.workspace.rootPath, `**/*{${getFileTypesSetting().join(",")}}`),
     false,
     false,
     false

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { TextDecoder } from "util";
 import * as path from "path";
 import { parseFile, parseDirectory, learnFileId } from "./parsing";
-import { filterNonExistingEdges, getColumnSetting, getConfiguration } from "./utils";
+import { filterNonExistingEdges, getColumnSetting, getConfiguration, getFileTypesSetting } from "./utils";
 import { Graph } from "./types";
 
 const watch = (
@@ -15,7 +15,7 @@ const watch = (
   }
 
   const watcher = vscode.workspace.createFileSystemWatcher(
-    new vscode.RelativePattern(vscode.workspace.rootPath, "**/*.md"),
+    new vscode.RelativePattern(vscode.workspace.rootPath, "**/*{" + getFileTypesSetting().join(",") +"}"),
     false,
     false,
     false

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -102,9 +102,9 @@ export const parseDirectory = async (
     const isDirectory = fileType === vscode.FileType.Directory;
     const isFile = fileType === vscode.FileType.File;
     const hiddenFile = fileName.startsWith(".");
-const isGraphFile = getFileTypesSetting().includes(
-  fileName.substr(fileName.lastIndexOf('.') + 1)
-)
+    const isGraphFile = getFileTypesSetting().includes(
+      fileName.substr(fileName.lastIndexOf('.') + 1)
+    )
 
     if (isDirectory && !hiddenFile) {
       promises.push(

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -102,7 +102,9 @@ export const parseDirectory = async (
     const isDirectory = fileType === vscode.FileType.Directory;
     const isFile = fileType === vscode.FileType.File;
     const hiddenFile = fileName.startsWith(".");
-    const isGraphFile = getFileTypesSetting().includes(fileName.substr(fileName.lastIndexOf('.')+1));
+const isGraphFile = getFileTypesSetting().includes(
+  fileName.substr(fileName.lastIndexOf('.') + 1)
+)
 
     if (isDirectory && !hiddenFile) {
       promises.push(

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -6,7 +6,7 @@ import * as wikiLinkPlugin from "remark-wiki-link";
 import * as frontmatter from "remark-frontmatter";
 import { MarkdownNode, Graph } from "./types";
 import { TextDecoder } from "util";
-import { findTitle, findLinks, id, FILE_ID_REGEXP } from "./utils";
+import { findTitle, findLinks, id, FILE_ID_REGEXP, getFileTypesSetting, getConfiguration } from "./utils";
 import { basename } from "path";
 
 let idToPath: Record<string, string> = {};
@@ -102,13 +102,13 @@ export const parseDirectory = async (
     const isDirectory = fileType === vscode.FileType.Directory;
     const isFile = fileType === vscode.FileType.File;
     const hiddenFile = fileName.startsWith(".");
-    const markdownFile = fileName.endsWith(".md");
+    const isGraphFile = getFileTypesSetting().includes(fileName.substr(fileName.lastIndexOf('.')+1));
 
     if (isDirectory && !hiddenFile) {
       promises.push(
         parseDirectory(graph, `${directory}/${fileName}`, fileCallback)
       );
-    } else if (isFile && markdownFile) {
+    } else if (isFile && isGraphFile) {
       promises.push(fileCallback(graph, `${directory}/${fileName}`));
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -84,6 +84,11 @@ export const getFileIdRegexp = () => {
 
 export const FILE_ID_REGEXP = getFileIdRegexp();
 
+export const getFileTypesSetting = () => {
+  const DEFAULT_VALUE = ["md"];
+  return getConfiguration("fileTypes") || DEFAULT_VALUE;
+};
+
 export const getDot = (graph: Graph) => `digraph g {
   ${graph.nodes
     .map((node) => `  ${node.id} [label="${node.label}"];`)


### PR DESCRIPTION
Adds a new setting called fileTypes (type array) which contains file extensions that should be included into the graph.

Default: ["md"]
Example usage: ["mdx", "md", "rmd",]

Heck, you could even include "txt" and it'd work.

This allows for users to take notes using other file formats, and have them still show up within the graph.

Although I've only changed a couple lines, I'd love for someone to review this PR. I've never really used JavaScript  :sweat_smile: 

Closes: #19 