### PR TITLE
Automatically update graph when new files are added

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,13 @@ const watch = (
     sendGraph();
   });
 
+  // Watch file creation in case user adds a new file
+  watcher.onDidCreate(async (event) => {
+    await parseFile(graph, event.path);
+    filterNonExistingEdges(graph);
+    sendGraph();
+  });
+
   watcher.onDidDelete(async (event) => {
     const index = graph.nodes.findIndex((node) => node.path === event.path);
     if (index === -1) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,22 @@
 import * as vscode from "vscode";
 import * as md5 from "md5";
+import { extname } from "path";
 import { MarkdownNode, Graph } from "./types";
 
 export const findLinks = (ast: MarkdownNode): string[] => {
   if (ast.type === "link" || ast.type === "definition") {
-    return [ast.url!];
+    // ignore empty, anchor and web links
+    if (
+      !ast.url ||
+      ast.url.startsWith("#") ||
+      vscode.Uri.parse(ast.url).scheme.startsWith("http")
+    ) {
+      return [];
+    }
+
+    return [ast.url];
   }
+
   if (ast.type === "wikiLink") {
     return [ast.data!.permalink!];
   }
@@ -42,12 +53,8 @@ export const findTitle = (ast: MarkdownNode): string | null => {
 };
 
 export const id = (path: string): string => {
-  return md5(path);
-
-  // Extracting file name without extension:
-  // const fullPath = path.split("/");
-  // const fileName = fullPath[fullPath.length - 1];
-  // return fileName.split(".")[0];
+  // Extracting file name without extension
+  return md5(path.substring(0, path.length - extname(path).length));
 };
 
 export const getConfiguration = (key: string) =>


### PR DESCRIPTION
Fixes #12 

- Changes the node id generation to always happen without file extension (since new wikilink nodes don't have them)
- Skips adding anchor and http links to the graph, since they get weeded out anyway
- Adds a listener to new created files and adds them to the graph

The downside is that, as you can see in the below demo, the graph gets a bit jumpy when new files are added. That's a separate issue IMO.

Demo:
![ggggg](https://user-images.githubusercontent.com/1203949/88329252-8fe53700-cd21-11ea-9fbd-e661f66d74ef.gif)
