### PR TITLE
Use workspace.findFiles to respect ignored files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,12 @@ import * as vscode from "vscode";
 import { TextDecoder } from "util";
 import * as path from "path";
 import { parseFile, parseDirectory, learnFileId } from "./parsing";
-import { filterNonExistingEdges, getColumnSetting, getConfiguration, getFileTypesSetting } from "./utils";
+import {
+  filterNonExistingEdges,
+  getColumnSetting,
+  getConfiguration,
+  getFileTypesSetting,
+} from "./utils";
 import { Graph } from "./types";
 
 const watch = (
@@ -15,7 +20,10 @@ const watch = (
   }
 
   const watcher = vscode.workspace.createFileSystemWatcher(
-    new vscode.RelativePattern(vscode.workspace.rootPath, `**/*{${getFileTypesSetting().join(",")}}`),
+    new vscode.RelativePattern(
+      vscode.workspace.rootPath,
+      `**/*{${getFileTypesSetting().join(",")}}`
+    ),
     false,
     false,
     false
@@ -128,8 +136,8 @@ export function activate(context: vscode.ExtensionContext) {
         edges: [],
       };
 
-      await parseDirectory(graph, vscode.workspace.rootPath, learnFileId);
-      await parseDirectory(graph, vscode.workspace.rootPath, parseFile);
+      await parseDirectory(graph, learnFileId);
+      await parseDirectory(graph, parseFile);
       filterNonExistingEdges(graph);
 
       const d3Uri = panel.webview.asWebviewUri(

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -33,6 +33,7 @@ const parser = unified()
   .use(frontmatter);
 
 export const parseFile = async (graph: Graph, filePath: string) => {
+  filePath = path.normalize(filePath);
   const buffer = await vscode.workspace.fs.readFile(vscode.Uri.file(filePath));
   const content = new TextDecoder("utf-8").decode(buffer);
   const ast: MarkdownNode = parser.parse(content);
@@ -59,10 +60,10 @@ export const parseFile = async (graph: Graph, filePath: string) => {
   graph.edges = graph.edges.filter((edge) => edge.source !== id(filePath));
 
   const links = findLinks(ast);
-  const parentDirectory = filePath.split("/").slice(0, -1).join("/");
+  const parentDirectory = filePath.split(path.sep).slice(0, -1).join(path.sep);
 
   for (const link of links) {
-    let target = link;
+    let target = path.normalize(link);
     if (!path.isAbsolute(link)) {
       target = path.normalize(`${parentDirectory}/${link}`);
     }

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -97,7 +97,7 @@ export const parseDirectory = async (
   fileCallback: (graph: Graph, path: string) => Promise<void>
 ) => {
   const files = await vscode.workspace.findFiles(
-    `**/*{${getFileTypesSetting().join(",")}}`
+    `**/*{${(getFileTypesSetting() as string[]).map((f) => `.${f}`).join(",")}}`
   );
 
   const promises: Promise<void>[] = [];

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -96,6 +96,8 @@ export const parseDirectory = async (
   graph: Graph,
   fileCallback: (graph: Graph, path: string) => Promise<void>
 ) => {
+  // `findFiles` is used here since it respects files excluded by either the
+  // global or workspace level files.exclude config option.
   const files = await vscode.workspace.findFiles(
     `**/*{${(getFileTypesSetting() as string[]).map((f) => `.${f}`).join(",")}}`
   );


### PR DESCRIPTION
This pull request aims to improve the performance of graph parsing when large folders are present (such as `node_modules`)

It does this by using [findFiles](https://code.visualstudio.com/api/references/vscode-api#workspace.findFiles) which respects files excluded by either the global or workspace level `files.exclude` config option.

In a follow up PR, I'd be quite interested to propose automatically excluding files from the workspaces `.gitignore`, but thought that should be put to a discussion first!

Resolves, if `files.exclude` is set: https://github.com/tchayen/markdown-links/issues/33
Relates to: https://github.com/foambubble/foam/issues/130

Thank you for this extension. Love being able to visualise the links between files!