### PR TITLE
Add a setting to cut titles after a certain length

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ A [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/G
 - `default` (**default**)
 - `obsidian` - obsidian like graph
 
+### `markdown-links.titleMaxLength`
+
+The maximum title length before being abbreviated. Set to 0 or less to disable.
+
+#### Example
+
+The sentence:
+
+```
+Type checking a multithreaded functional language with session types
+```
+
+When abbreviated for a maximum length of 24, becomes:
+
+```
+Type checking a multithr...
+```
+
 ## Roadmap
 
 Plans for development are roughly summarized in the [Roadmap](docs/roadmap.md).

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "markdown-links.titleMaxLength": {
           "type": "number",
           "default": 24,
-          "description": "The maximum title length before being abbreviated."
+          "description": "The maximum title length before being abbreviated. Set to 0 or less to disable."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
           ],
           "default": "default",
           "description": "Choose type of graph appearance."
+        },
+        "markdown-links.titleMaxLength": {
+          "type": "number",
+          "default": 24,
+          "description": "The maximum title length before being abbreviated."
         }
       }
     }

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -51,11 +51,6 @@ export const parseFile = async (graph: Graph, filePath: string) => {
     return;
   }
 
-  const titleMaxLength = getTitleMaxLength();
-  if (titleMaxLength > 0 && title.length > titleMaxLength) {
-    title = title.substr(0, titleMaxLength).concat("...");
-  }
-
   if (index !== -1) {
     graph.nodes[index].label = title;
   } else {

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -13,6 +13,7 @@ import {
   FILE_ID_REGEXP,
   getFileTypesSetting,
   getConfiguration,
+  getTitleMaxLength,
 } from "./utils";
 import { basename } from "path";
 
@@ -48,6 +49,11 @@ export const parseFile = async (graph: Graph, filePath: string) => {
     }
 
     return;
+  }
+
+  const titleMaxLength = getTitleMaxLength();
+  if (titleMaxLength > 0 && title.length > titleMaxLength) {
+    title = title.substr(0, titleMaxLength).concat("...");
   }
 
   if (index !== -1) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,6 +74,10 @@ const settingToValue: { [key: string]: vscode.ViewColumn | undefined } = {
   nine: 9,
 };
 
+export const getTitleMaxLength = () => {
+  return getConfiguration("titleMaxLength");
+}
+
 export const getColumnSetting = (key: string) => {
   const column = getConfiguration(key);
   return settingToValue[column] || vscode.ViewColumn.One;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,14 @@ export const findTitle = (ast: MarkdownNode): string | null => {
       child.children &&
       child.children.length > 0
     ) {
-      return child.children[0].value!;
+      let title = child.children[0].value!
+
+      const titleMaxLength = getTitleMaxLength();
+      if (titleMaxLength > 0 && title.length > titleMaxLength) {
+        title = title.substr(0, titleMaxLength).concat("...");
+      }
+
+      return title;
     }
   }
   return null;


### PR DESCRIPTION
This PR is directly related to #66 

The idea is to simple cut/abbreviate long titles by setting a limit (current default is 24) and after the limit append ...