### PR TITLE
Introduce searchGlob configuration. Allows to define where to look for the files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Controls in which column should clicked files open. Refer to [Column values](###
 
 A [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions) used to find the file ID for use in wiki-style links.
 
+### `markdown-links.searchGlob`
+
+[Glob pattern](https://code.visualstudio.com/api/references/vscode-api#GlobPattern) used to find files to parse with the Markdown Links extension. Handy in a case that you want only a  part of your workspace parsed.
+
 ### `markdown-links.graphType`
 
 - `default` (**default**)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,12 @@
         "markdown-links.fileIdRegexp": {
           "type": "string",
           "default": "\\d{14}",
-          "description": "Regular extension used to find file IDs. First match of this regex in file contents, excluding [[links]], will be used as the file ID. This file ID can be used for wiki-style links."
+          "description": "Regular expression used to find file IDs. First match of this regex in file contents, excluding [[links]], will be used as the file ID. This file ID can be used for wiki-style links."
+        },
+        "markdown-links.searchGlob" : {
+          "type": "string",
+          "description": "Glob pattern used to find files to parse with the Markdown Links extension. https://code.visualstudio.com/api/references/vscode-api#GlobPattern",
+          "examples": ["**/*.md", "notes-folder/*.md"]
         },
         "markdown-links.autoStart": {
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import {
   filterNonExistingEdges,
   getColumnSetting,
   getConfiguration,
-  getFileTypesSetting,
+  getFileSearchExpression,
 } from "./utils";
 import { Graph } from "./types";
 
@@ -22,7 +22,7 @@ const watch = (
   const watcher = vscode.workspace.createFileSystemWatcher(
     new vscode.RelativePattern(
       vscode.workspace.rootPath,
-      `**/*{${getFileTypesSetting().join(",")}}`
+      getFileSearchExpression()
     ),
     false,
     false,

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -11,9 +11,7 @@ import {
   findLinks,
   id,
   FILE_ID_REGEXP,
-  getFileTypesSetting,
-  getConfiguration,
-  getTitleMaxLength,
+  getFileSearchExpression,
 } from "./utils";
 import { basename } from "path";
 
@@ -100,9 +98,7 @@ export const parseDirectory = async (
 ) => {
   // `findFiles` is used here since it respects files excluded by either the
   // global or workspace level files.exclude config option.
-  const files = await vscode.workspace.findFiles(
-    `**/*{${(getFileTypesSetting() as string[]).map((f) => `.${f}`).join(",")}}`
-  );
+  const files = await vscode.workspace.findFiles(getFileSearchExpression());
 
   const promises: Promise<void>[] = [];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,9 +102,10 @@ export const getFileIdRegexp = () => {
 
 export const FILE_ID_REGEXP = getFileIdRegexp();
 
-export const getFileTypesSetting = () => {
+export const getFileSearchExpression = () => {
   const DEFAULT_VALUE = ["md"];
-  return getConfiguration("fileTypes") || DEFAULT_VALUE;
+  const fileTypes = getConfiguration("fileTypes") || DEFAULT_VALUE;
+  return `**/*{${(fileTypes as string[]).map((f) => `.${f}`).join(",")}}`;
 };
 
 export const getDot = (graph: Graph) => `digraph g {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,7 @@ export const findTitle = (ast: MarkdownNode): string | null => {
       child.children &&
       child.children.length > 0
     ) {
-      let title = child.children[0].value!
+      let title = child.children[0].value!;
 
       const titleMaxLength = getTitleMaxLength();
       if (titleMaxLength > 0 && title.length > titleMaxLength) {
@@ -83,7 +83,7 @@ const settingToValue: { [key: string]: vscode.ViewColumn | undefined } = {
 
 export const getTitleMaxLength = () => {
   return getConfiguration("titleMaxLength");
-}
+};
 
 export const getColumnSetting = (key: string) => {
   const column = getConfiguration(key);
@@ -102,10 +102,20 @@ export const getFileIdRegexp = () => {
 
 export const FILE_ID_REGEXP = getFileIdRegexp();
 
-export const getFileSearchExpression = () => {
+export const getFileSearchExpression = (): string => {
+  const configFileTypes: string[] = getConfiguration("fileTypes");
+  const searchGlob: string = getConfiguration("searchGlob");
+  if (searchGlob) {
+    if (configFileTypes) {
+      vscode.window.showWarningMessage(
+        "You have both fileTypes and searchGlob settings defined, searchGlob is taking precedence."
+      );
+    }
+    return searchGlob;
+  }
   const DEFAULT_VALUE = ["md"];
-  const fileTypes = getConfiguration("fileTypes") || DEFAULT_VALUE;
-  return `**/*{${(fileTypes as string[]).map((f) => `.${f}`).join(",")}}`;
+  const fileTypes = configFileTypes || DEFAULT_VALUE;
+  return `**/*{${fileTypes.map((f) => `.${f}`).join(",")}}`;
 };
 
 export const getDot = (graph: Graph) => `digraph g {


### PR DESCRIPTION
Closes #63 

This PR introduces a new configuration option, `searchGlob`. The configuration option is `null` by default and doesn't interfere with the current logic.

If set, the option overrides the expression generated from `fileTypes` configuration. If the `fileTypes` configuration has been set, we'll warn the user:

<img width="558" alt="Screenshot 2020-10-25 at 11 49 19 AM" src="https://user-images.githubusercontent.com/1079718/97105161-35a99880-16b9-11eb-841e-a7e9419abb4e.png">

This PR contains 3 commits:

1. first commit only refactors the code in prepration for a chagne. There's no functionality change
1. second commit implements the change
1. third commit adds README entry
