### PR TITLE
Decode URI to allow links with spaces

### DIFF
--- a/examples/functionality/With spaces - should work too.md
+++ b/examples/functionality/With spaces - should work too.md
@@ -1,3 +1,4 @@
 # With spaces - should work too
 
 [Next](next.md)
+[Another space](such%20space/With%20spaces%20-%20nested.md)

--- a/examples/functionality/such space/With spaces - nested.md
+++ b/examples/functionality/such space/With spaces - nested.md
@@ -1,0 +1,3 @@
+# With spaces - nested
+
+[Next](../nested/nested.md)

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -60,7 +60,8 @@ export const parseFile = async (graph: Graph, filePath: string) => {
   // Remove edges based on an old version of this file.
   graph.edges = graph.edges.filter((edge) => edge.source !== id(filePath));
 
-  const links = findLinks(ast);
+  // Returns a list of decoded links (by default markdown only supports encoded URI)
+  const links = findLinks(ast).map(uri => decodeURI(uri));
   const parentDirectory = filePath.split(path.sep).slice(0, -1).join(path.sep);
 
   for (const link of links) {


### PR DESCRIPTION
Decode links coming from unified library. This should allow cases like the one reported on https://github.com/tchayen/markdown-links/issues/18