### PR TITLE
Bind fileOpen message to change active text editor event

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,10 +66,13 @@ const watch = (
     sendGraph();
   });
 
-  vscode.workspace.onDidOpenTextDocument(async (event) => {
+  vscode.window.onDidChangeActiveTextEditor(async (event) => {
+    if (!event) {
+      return;
+    }
     panel.webview.postMessage({
       type: "fileOpen",
-      payload: { path: event.fileName },
+      payload: { path: event!.document.fileName },
     });
   });
 


### PR DESCRIPTION
The active node in the graph only updates when switching to a previously unopened file. Binding to a different event fixes it to also work when switching tabs to already opened files.