### PR TITLE
Support Yaml frontmatter as Title

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,7 +38,23 @@ export const findTitle = (ast: MarkdownNode): string | null => {
   if (!ast.children) {
     return null;
   }
+  
+  // Prefer to find the title field in front-matter (yaml)
+  for (const child of ast.children) {
+    if (child.type === "yaml" && child.value) {
+      const match = child.value.match(/^title:\s*(.+)$/m);
+      if (match && match[1]) {
+        let title = match[1].trim().replace(/^['"]|['"]$/g, "");
+        const titleMaxLength = getTitleMaxLength();
+        if (titleMaxLength > 0 && title.length > titleMaxLength) {
+          title = title.substr(0, titleMaxLength).concat("...");
+        }
+        return title;
+      }
+    }
+  }
 
+  // If no front-matter title, fallback to first-level heading
   for (const child of ast.children) {
     if (
       child.type === "heading" &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export const findTitle = (ast: MarkdownNode): string | null => {
   // Prefer to find the title field in front-matter (yaml)
   for (const child of ast.children) {
     if (child.type === "yaml" && child.value) {
-      const match = child.value.match(/^title:\s*(.+)$/m);
+      const match = child.value.match(/^title:\s*(.+)$/im);
       if (match && match[1]) {
         let title = match[1].trim().replace(/^['"]|['"]$/g, "");
         const titleMaxLength = getTitleMaxLength();


### PR DESCRIPTION
When using the plugin, I observed that it only utilized Markdown level-1 headings as nodes. However, my files do not use level-1 headings; instead, they define titles via the `title` field in the frontmatter. After identifying the identical issue raised in [#93](https://github.com/tchayen/markdown-links/issues/93), I created a new branch based on PR [#96](https://github.com/tchayen/markdown-links/pull/96) and modified the relevant code. Testing confirmed that this change enables the use of fields like `title` or `Title` as node titles on Windows.

I have not tested this change on other systems, such as Linux.